### PR TITLE
Update abelsiqueira/COPIERTemplate.jl to JuliaBesties/BestieTemplate.jl

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,4 +9,4 @@ PackageName: TulipaProfileFitting
 PackageOwner: TulipaEnergy
 PackageUUID: 0aa31362-0b7e-4e8d-8385-676712fa7ef3
 _commit: v0.7.0
-_src_path: https://github.com/abelsiqueira/COPIERTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
